### PR TITLE
Pin sqlparse, yapf versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup_params = dict(
     include_package_data=True,
     description='convert sql to sqlalchemy expressions',
     install_requires=[
-        'sqlparse',
+        'sqlparse==0.2.0',
     ],
     entry_points={
         'console_scripts': [

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,5 +3,5 @@ pytest
 pytest-xdist
 pytest-catchlog
 flake8
-yapf
+yapf==0.16.1
 sqlalchemy

--- a/tests/db.py
+++ b/tests/db.py
@@ -6,14 +6,10 @@ from sqlalchemy import (
 metadata = MetaData()
 
 foo = Table(
-    'foo',
-    metadata,
+    'foo', metadata,
     Column(
         'id', Integer, nullable=False, primary_key=True, autoincrement=True
-    ),
-    Column(
-        'name', String(256), nullable=False
-    )
+    ), Column('name', String(256), nullable=False)
 )
 
 bar = Table(
@@ -22,14 +18,8 @@ bar = Table(
     Column(
         'id', Integer, nullable=False, primary_key=True, autoincrement=True
     ),
-    Column(
-        'foo_id', ForeignKey(
-            foo.c.id, ondelete='CASCADE'
-        ), nullable=False
-    ),
-    Column(
-        'name', String(256), nullable=False
-    ),
+    Column('foo_id', ForeignKey(foo.c.id, ondelete='CASCADE'), nullable=False),
+    Column('name', String(256), nullable=False),
 )
 
 wumbo = Table(
@@ -38,25 +28,11 @@ wumbo = Table(
     Column(
         'id', Integer, nullable=False, primary_key=True, autoincrement=True
     ),
-    Column(
-        'foo_id', ForeignKey(
-            foo.c.id, ondelete='CASCADE'
-        ), nullable=False
-    ),
-    Column(
-        'bar_id', ForeignKey(
-            bar.c.id, ondelete='CASCADE'
-        ), nullable=False
-    ),
-    Column(
-        'name', String(256), nullable=False
-    ),
-    Column(
-        'timestamp', Integer, nullable=False
-    ),
-    Column(
-        'result', String(256), nullable=False
-    ),
+    Column('foo_id', ForeignKey(foo.c.id, ondelete='CASCADE'), nullable=False),
+    Column('bar_id', ForeignKey(bar.c.id, ondelete='CASCADE'), nullable=False),
+    Column('name', String(256), nullable=False),
+    Column('timestamp', Integer, nullable=False),
+    Column('result', String(256), nullable=False),
 )
 
 bar_tags = Table(
@@ -65,12 +41,8 @@ bar_tags = Table(
     Column(
         'id', Integer, nullable=False, primary_key=True, autoincrement=True
     ),
-    Column(
-        'bar_id', Integer, nullable=False
-    ),
-    Column(
-        'tag_id', Integer, nullable=False
-    ),
+    Column('bar_id', Integer, nullable=False),
+    Column('tag_id', Integer, nullable=False),
 )
 
 wumbo_tags_table = Table(
@@ -79,27 +51,17 @@ wumbo_tags_table = Table(
     Column(
         'id', Integer, nullable=False, primary_key=True, autoincrement=True
     ),
-    Column(
-        'wumbo_id', Integer, nullable=False
-    ),
-    Column(
-        'tag_id', Integer, nullable=False
-    ),
+    Column('wumbo_id', Integer, nullable=False),
+    Column('tag_id', Integer, nullable=False),
 )
 
 tags = Table(
-    'tags',
-    metadata,
+    'tags', metadata,
     Column(
         'id', Integer, nullable=False, primary_key=True, autoincrement=True
     ),
-    Column(
-        'key', Text, nullable=False
-    ),
-    Column(
-        'value', Text, nullable=False
-    ),
-    UniqueConstraint('key', 'value')
+    Column('key', Text, nullable=False),
+    Column('value', Text, nullable=False), UniqueConstraint('key', 'value')
 )
 
 


### PR DESCRIPTION
- Pin sqlparse to a known working version. This resolves a breakage seen
with new version of sqlparse.
- Pins yapf, so code formatting doesn't change with yapf versions.
- (All the code updates are just formatting changes)