### PR TITLE
Add support for 'select distinct'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,14 +51,14 @@ Use tox to run the tests.
     $ tox -e py27
     ### Run just style/formatting checks
     $ tox -e flake8
-    
+
 `yapf`_ is used to automatically fix code style/formatting errors. It will reformat your code in place.
 
 .. code-block:: bash
 
     ### Auto-fix style/formatting checks
     $ tox -e yapf
-    
+
 There are three types of tests:
 
 - Unit tests of the internal models
@@ -66,7 +66,7 @@ There are three types of tests:
 - Functional tests that execute the generated SQLAlchemy expressions, against a sqlite database.
 
 Most of these tests are generated from data in ``tests/data.json``.
-    
+
 SQL Support Checklist
 ---------------------
 
@@ -81,7 +81,7 @@ SQL Support Checklist
     - [x] Select from subquery: ``SELECT id FROM (SELECT * FROM foo)``
     - [x] Where: ``SELECT id FROM foo WHERE id = 123``
     - [ ] Between: ``SELECT a FROM foo WHERE foo.val BETWEEN 1 AND 20``
-    - [ ] Select distinct: ``SELECT DISTINCT a FROM foo``
+    - [x] Select distinct: ``SELECT DISTINCT a FROM foo``
     - [ ] Aggregate functions (SUM, AVG, COUNT, MIN, MAX): ``SELECT COUNT(*) FROM foo``
     - [ ] Group by: ``SELECT COUNT(*) FROM foo GROUP BY column``
     - [ ] Like

--- a/sqlitis/convert.py
+++ b/sqlitis/convert.py
@@ -73,6 +73,8 @@ def tokens_to_sqla(tokens):
 
         if tok.normalized == 'SELECT':
             m = m.Select()
+        elif tok.normalized == 'DISTINCT':
+            m = m.Distinct()
         elif tok.normalized == 'FROM':
             m = m.From()
         elif tok.normalized == 'JOIN':
@@ -98,7 +100,9 @@ def tokens_to_sqla(tokens):
                 cols.append(M.Field(x.normalized, alias=x.get_alias()))
             m = m.Columns(cols)
         elif type(tok) is S.Identifier:
-            if prev_tok is not None and prev_tok.normalized == 'SELECT':
+            if prev_tok is not None and prev_tok.normalized in [
+                'SELECT', 'DISTINCT'
+            ]:
                 m = m.Columns([M.Field(tok.normalized, alias=tok.get_alias())])
             else:
                 m = m.Table(tok.normalized)

--- a/tests/data.json
+++ b/tests/data.json
@@ -52,6 +52,80 @@
       [2, 1, "xyz"]
     ]
   },
+  "select_distinct": {
+    "sql": "select distinct",
+    "sqla": "select().distinct()"
+  },
+  "select_distinct_column_from_table": {
+    "sql": "select distinct name from foo",
+    "sqla": "select([foo.c.name]).distinct()",
+    "data": {
+      "foo": [
+        { "name": "abc" },
+        { "name": "abc" },
+        { "name": "xyz" },
+        { "name": "xyz" }
+      ]
+    },
+    "output": [
+      ["abc"],
+      ["xyz"]
+    ]
+  },
+  "select_distinct_from_table_with_where_clause": {
+    "sql": "select distinct name from foo where foo.name = \"abc\"",
+    "sqla": "select([foo.c.name]).distinct().where(foo.c.name == \"abc\")",
+    "data": {
+      "foo": [
+        { "name": "abc" },
+        { "name": "abc" },
+        { "name": "xyz" },
+        { "name": "xyz" }
+      ]
+    },
+    "output": [
+      ["abc"]
+    ]
+  },
+  "select_distinct_from_join": {
+    "sql": "select distinct foo.name from foo join bar",
+    "sqla": "select([foo.c.name]).select_from(foo.join(bar)).distinct()",
+    "data": {
+      "foo": [
+        { "name": "abc" },
+        { "name": "xyz" }
+      ],
+      "bar": [
+        { "foo_id": 1, "name": "bar_abc" },
+        { "foo_id": 1, "name": "bar_abc" },
+        { "foo_id": 2, "name": "bar_xyz" },
+        { "foo_id": 2, "name": "bar_xyz" }
+      ]
+    },
+    "output": [
+      ["abc"],
+      ["xyz"]
+    ]
+  },
+  "select_distinct_from_join_with_where": {
+    "sql": "SELECT DISTINCT foo.name FROM foo JOIN bar WHERE bar.name = \"bar_abc\"",
+    "sqla": "select([foo.c.name]).select_from(foo.join(bar)).distinct().where(bar.c.name == \"bar_abc\")",
+    "data": {
+      "foo": [
+        { "name": "abc" },
+        { "name": "xyz" }
+      ],
+      "bar": [
+        { "foo_id": 1, "name": "bar_abc" },
+        { "foo_id": 1, "name": "bar_abc" },
+        { "foo_id": 2, "name": "bar_xyz" },
+        { "foo_id": 2, "name": "bar_xyz" }
+      ]
+    },
+    "output": [
+      ["abc"]
+    ]
+  },
   "select_qualified_columns_from_table": {
     "sql": "select foo.id, foo.name from foo",
     "sqla": "select([foo.c.id, foo.c.name])"


### PR DESCRIPTION
Some examples:

```
$ sqlitis 'select distinct'
select().distinct()

$ sqlitis 'select distinct * from foo'
select([foo]).distinct()

$ sqlitis 'select distinct a from foo'
select([foo.c.a]).distinct()

$ sqlitis 'select distinct id, name from foo'
select([foo.c.id, foo.c.name]).distinct()

$ sqlitis 'select distinct foo.id, foo.name from foo'
select([foo.c.id, foo.c.name]).distinct()

$ sqlitis 'select distinct age from foo where name="pglass"'
select([foo.c.age]).distinct().where(text('name') == "pglass")

$ sqlitis 'select distinct age from foo where foo.name="pglass"'
select([foo.c.age]).distinct().where(foo.c.name == "pglass")
```