### PR TITLE
Support quoted identifiers and fix for multiple joins

### DIFF
--- a/sqlitis/convert.py
+++ b/sqlitis/convert.py
@@ -127,6 +127,12 @@ def tokens_to_sqla(tokens):
                 )
                 sub = tokens_to_sqla(subtokens)
                 m = m.Table(sub)
+        elif tok.is_keyword:
+            # Not the right error message in all cases, but better than nothing
+            raise Exception(
+                "Unexpected keyword '{0}'. Maybe you need to quote: `{0}`?"
+                .format(tok.normalized)
+            )
 
         LOG.debug("%s %s", i, type(m))
         i += 1
@@ -204,6 +210,8 @@ def comparison_to_sqla(tokens):
             m = sql_literal_to_model(tok)
             _shift(m, ARGS)
         else:
+            # don't count unconsumed tokens
+            count -= 1
             break
 
         LOG.debug("%s: OPS=%s ARGS=%s", count, OPS, ARGS)

--- a/sqlitis/models.py
+++ b/sqlitis/models.py
@@ -4,9 +4,10 @@ class Base(object):
         return ''
 
 
-def convert_column(col, table=None):
+def convert_column(col, table=None, quote_open='`', quote_close='`'):
     """Turns foo.id into foo.c.id. If a table is given, then id becomes
     <table>.c.id"""
+    col = col.replace(quote_open, '').replace(quote_close, '')
     if '.' in col and table and not col.startswith(table.name):
         raise Exception("field %s invalid for table %s" % (col, table.name))
     elif '.' in col:
@@ -17,6 +18,10 @@ def convert_column(col, table=None):
         return '%s.c.%s' % (table.name, col)
     else:
         return "text('%s')" % col
+
+
+def unquote_quoted_table_name(name, quote_open='`', quote_close='`'):
+    return name.lstrip(quote_open).rstrip(quote_close)
 
 
 class Select(Base):
@@ -129,7 +134,7 @@ class SelectFromWhere(Base):
 class Table(Base):
 
     def __init__(self, name):
-        self.name = name
+        self.name = unquote_quoted_table_name(name)
 
     def Join(self, table):
         return Join(self, table)

--- a/tests/data.yaml
+++ b/tests/data.yaml
@@ -1,6 +1,8 @@
 join_on_condition_equal:
   sql:
   - foo join bar on foo.id > bar.foo_id
+  - '`foo` join bar on foo.id > bar.foo_id'
+  - '`foo` join `bar` on foo.id > bar.foo_id'
   - foo inner join bar on foo.id > bar.foo_id
   sqla: foo.join(bar, foo.c.id > bar.c.foo_id)
 
@@ -45,7 +47,11 @@ join_on_expr_or_expr:
   sqla: foo.join(bar, or_(foo.c.id == bar.c.foo_id, bar.c.val > 1))
 
 join_three_tables:
-  sql: foo join bar join baz
+  sql:
+  - foo join bar join baz
+  - foo inner join bar join baz
+  - foo join bar inner join baz
+  - foo inner join bar inner join baz
   sqla: foo.join(bar).join(baz)
 
 join_two_tables:
@@ -80,7 +86,8 @@ select_columns:
 select_columns_from_join:
   sql:
   - select foo.id, bar.id, foo.name, bar.name from foo join bar
-  - select foo.id, bar.id, foo.name, bar.name from inner foo join bar
+  - select foo.id, bar.id, foo.name, bar.name from foo inner join bar
+  - select `foo`.`id`, `bar`.`id`, `foo`.`name`, `bar`.`name` from `foo` join `bar`
   sqla: select([foo.c.id, bar.c.id, foo.c.name, bar.c.name]).select_from(foo.join(bar))
   data:
     bar:
@@ -299,3 +306,49 @@ select_star_from_table:
   output:
   - [1, "abc"]
   - [2, "xyz"]
+
+select_star_from_keyword:
+  sql:
+  - select * from user
+  - select * from table
+  sqla: ''
+  exception: |
+    Unexpected keyword '\w+'. Maybe you need to quote: `\w+`\?
+
+select_star_from_three_joined_tables:
+  sql:
+  - select * from foo join bar join wumbo
+  - select * from foo inner join bar join wumbo
+  - select * from foo join bar inner join wumbo
+  - select * from foo inner join bar inner join wumbo
+  sqla: select([foo.join(bar).join(wumbo)])
+  data:
+    foo:
+      - {name: "abc"}
+    bar:
+      - {name: "123", foo_id: 1}
+    wumbo:
+      - {name: "squidward", timestamp: 1234, result: "good", bar_id: 1, foo_id: 1}
+  output:
+    - [
+      1, 'abc',                            # foo: id, name
+      1, 1, '123',                         # bar: id, foo_id, name,
+      1, 1, 1, "squidward", 1234, 'good',  # wumbo: id, foo_id, bar_id, name, timestamp, result
+    ]
+
+select_star_from_joined_tables_with_condition:
+  sql: select * from foo join bar on foo.id = bar.foo_id join wumbo on foo.id = wumbo.foo_id
+  sqla: select([foo.join(bar, foo.c.id == bar.c.foo_id).join(wumbo, foo.c.id == wumbo.c.foo_id)])
+  data:
+    foo:
+      - {name: "abc"}
+    bar:
+      - {name: "123", foo_id: 1}
+    wumbo:
+      - {name: "squidward", timestamp: 1234, result: "good", bar_id: 1, foo_id: 1}
+  output:
+    - [
+      1, 'abc',                            # foo: id, name
+      1, 1, '123',                         # bar: id, foo_id, name,
+      1, 1, 1, "squidward", 1234, 'good',  # wumbo: id, foo_id, bar_id, name, timestamp, result
+    ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -61,3 +61,12 @@ class TestModels(unittest.TestCase):
             m.render(), 'foo.join(bar, and_(foo.c.id == bar.c.foo_id, '
             'foo.c.val != bar.c.thing))'
         )
+
+    def test_join_on_condition_join_table(self):
+        m = Table('foo').Join('bar').\
+            On().Field('foo.id').Op('=').Field('bar.foo_id').\
+            Join('wumbo').On().Field('foo.id').Op('=').Field('wumbo.foo_id')
+        self.assertEqual(
+            m.render(), 'foo.join(bar, foo.c.id == bar.c.foo_id)'
+            '.join(wumbo, foo.c.id == wumbo.c.foo_id)'
+        )


### PR DESCRIPTION
- Quoted table or column names are now supported + tests
- Error when an unhandled keyword would otherwise be ignored + test
- A fix for multiple joins + test

Fixes #19 